### PR TITLE
Add hasMiddlewareGroup and getMiddlewareGroups methods

### DIFF
--- a/src/Illuminate/Routing/Router.php
+++ b/src/Illuminate/Routing/Router.php
@@ -682,6 +682,27 @@ class Router implements RegistrarContract, BindingRegistrar
     }
 
     /**
+     * Check if a middlewareGroup with the given name exists.
+     *
+     * @param  string  $name
+     * @return bool
+     */
+    public function hasMiddlewareGroup($name)
+    {
+        return array_key_exists($name, $this->middlewareGroups);
+    }
+    
+    /**
+     * Get all of the defined middleware groups.
+     *
+     * @return array
+     */
+    public function getMiddlewareGroups()
+    {
+        return $this->middlewareGroups;
+    }
+    
+    /**
      * Register a group of middleware.
      *
      * @param  string  $name


### PR DESCRIPTION
Handy method to be used when you want to register Middleware from a ServiceProvider and use: 
prependMiddlewareToGroup
pushMiddlewareToGroup
Because they gracefully fail to add a middleware if a group is not existing first.
Also you can use:
middlewareGroup($name, array $middleware)
but still you can't be sure if you are overwriting an existing group ... since there is no way to check if the group already exist.
Also adding getMiddlewareGroups method just for convenience if you want to check multiple groups or do something in a foreach loop.